### PR TITLE
fixed null pointer

### DIFF
--- a/library/src/main/java/com/qiniu/android/netdiag/TraceRoute.java
+++ b/library/src/main/java/com/qiniu/android/netdiag/TraceRoute.java
@@ -158,8 +158,8 @@ public final class TraceRoute implements Task {
             ip = getIp(this.address);
         } catch (UnknownHostException e) {
             e.printStackTrace();
-            updateOut("unknown host " + this.address);
             result = new Result("");
+            updateOut("unknown host " + this.address);
             this.complete.complete(result);
             return;
         }


### PR DESCRIPTION
May cause null pointer exception when failed to running "::getIp" function.